### PR TITLE
Added SSL capability to mongodb client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,10 +50,7 @@ RUN apt-get update && apt-get -y install \
     libzip-dev \
     libonig-dev \
     libpng-dev \
-    libmemcached-dev \
-    openssl \
-    libssl-dev \
-    libcurl4-openssl-dev
+    libmemcached-dev
 
 # install php extensions
 RUN docker-php-ext-install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,10 @@ RUN apt-get update && apt-get -y install \
     libzip-dev \
     libonig-dev \
     libpng-dev \
-    libmemcached-dev
+    libmemcached-dev \
+    openssl \
+    libssl-dev \
+    libcurl4-openssl-dev
 
 # install php extensions
 RUN docker-php-ext-install \

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ $ docker run -d --name fusio \
   --link fusio-db:db \
   -e "FUSIO_PROJECT_KEY=42eec18ffdbffc9fda6110dcc705d6ce" \
   -e "FUSIO_HOST=acme.com" \
+  -e "FUSIO_URL=acme.com" \
   -e "FUSIO_ENV=dev" \
   -e "FUSIO_DB_USER=fusio" \
   -e "FUSIO_DB_PW=61ad6c605975" \


### PR DESCRIPTION
Current Docker image is not capable to connect to MongoDB Atlas because it's compiled without SSL is disabled. This fixes it by installing pre-requisites to compile the php mongodb extension with SSL support.
Further, the parameter FUSIO_URL needs to be passed on if it happens to not be "acme.com". Otherwise, the client throws an error as it tries to get a token from http://acme.com/authorization/token